### PR TITLE
CB-12730: Compat - INTEGRATE

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,17 @@
         "ecosystem:phonegap",
         "cordova-android"
     ],
-    "engines": [
-        {
-            "name": "cordova",
-            "version": ">=5.0.0"
+    "engines": {
+      "cordovaDependencies": {
+        "<1.2.0": {
+          "cordova": ">=5.0.0"
+        },
+        "1.2.0": {
+          "cordova": ">=5.0.0",
+          "cordova-android": "<6.3.0"
         }
-    ],
+      }
+    },
     "author": "Apache Software Foundation",
     "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cordova-plugin-compat",
     "description": "This repo is for remaining backwards compatible with previous versions of Cordova.",
-    "version": "1.1.1-dev",
+    "version": "1.2.0-dev",
     "homepage": "http://github.com/apache/cordova-plugin-compat#readme",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
         "cordova-android"
     ],
     "engines": {
-      "cordovaDependencies": {
-        "<1.2.0": {
-          "cordova": ">=5.0.0"
-        },
-        "1.2.0": {
-          "cordova": ">=5.0.0",
-          "cordova-android": "<6.3.0"
+        "cordovaDependencies": {
+            "<1.2.0": {
+                "cordova": ">=5.0.0"
+            },
+            ">=1.2.0": {
+                "cordova": ">=5.0.0",
+                "cordova-android": "<6.3.0"
+            }
         }
-      }
     },
     "author": "Apache Software Foundation",
     "license": "Apache-2.0"

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
            id="cordova-plugin-compat"
-      version="1.1.1-dev">
+      version="1.2.0-dev">
     <name>Compat</name>
     <description>Cordova Compatibility Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,11 @@
     <keywords>cordova,compat</keywords>
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-compat.git</repo>
 
+    <engines>
+      <engine name="cordova" version=">=5.0.0"/>
+      <engine name="cordova-android" version="<6.3.0"/>
+    </engines>
+
     <!-- android -->
     <platform name="android">
       <source-file src="src/android/PermissionHelper.java" target-dir="src/org/apache/cordova" />


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Now that the code included in this plugin has been included in cordova-android master for the 6.3.0 release, the installation of this plugin should be skipped on projects using cordova-android 6.3.0 or greater.

### What testing has been done on this change?

First Project
- Created a version of cordova-plugin-camera that had the dependency tag for cordova-plugin-compat deleted.
- Added the custom cordova-plugin-camera to the project
- Added cordova-android 6.2.3 to the project
- Attempted to build the project, it failed as PermissionHelper was missing
- Added https://github.com/macdonst/cordova-plugin-compat-1 to the project
- Built project, ran it on Android, attempted to take a picture and was asked for permission and the picture was taken successfully

Second Project
- Added the custom cordova-plugin-camera to the project
- Added cordova-android 6.3.0 to the project
- Built project, ran it on Android, attempted to take a picture and was asked for permission and the picture was taken successfully

Third Project
- Added the custom cordova-plugin-camera to the project
- Added cordova-android 6.3.0 to the project
- Attempted to add cordova-plugin-compat 1.2.0 to the project but it was skipped as it won't install on cordova-android 6.3.0 or greater
- Built project, ran it on Android, attempted to take a picture and was asked for permission and the picture was taken successfully

Fourth Project
- Added the custom cordova-plugin-camera to the project
- Added cordova-plugin-compat 1.2.0 to the project
- Added cordova-android 6.3.0 to the project
- Built project, ran it on Android, attempted to take a picture and was asked for permission and the picture was taken successfully

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
